### PR TITLE
Static info styling -> develop

### DIFF
--- a/public/static/om-oss/statutter.md
+++ b/public/static/om-oss/statutter.md
@@ -40,8 +40,8 @@ Statutter
 4. Allmøter skal arrangeres når Styret mener at det foreligger saker eller situasjoner som er viktige for instituttets studenter.
 
 5. Det skal også innkalles til allmøte når:
-    - minst 10 personer krever det, eller
-    - ett medlem av Styret krever det.
+  - minst 10 personer krever det, eller
+  - ett medlem av Styret krever det.
 
 6. Allmøtet skal ha en dagsorden. Foreløpig dagsorden skal gjøres kjent for studentene samtidig med innkalling.
 

--- a/src/components/__tests__/bedpres-block.test.tsx
+++ b/src/components/__tests__/bedpres-block.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { screen } from '@testing-library/react';
 import { render } from './testing-utils';
 import BedpresBlock from '../bedpres-block';
 import { Bedpres } from '../../lib/types';

--- a/src/components/bedpres-block.tsx
+++ b/src/components/bedpres-block.tsx
@@ -12,6 +12,7 @@ import {
     Heading,
     Spacer,
     useColorModeValue,
+    Avatar,
 } from '@chakra-ui/react';
 import NextLink from 'next/link';
 import { format } from 'date-fns';
@@ -26,18 +27,11 @@ const BedpresBox = ({ bedpres }: { bedpres: Bedpres }): JSX.Element => {
         <LinkBox>
             <Box display="block" p="5" _hover={{ backgroundColor: hoverColor }}>
                 <Flex verticalAlign="middle">
-                    <Img
-                        htmlWidth="120px"
-                        htmlHeight="120px"
-                        objectFit="cover"
-                        borderRadius="100%"
-                        src={bedpres.logoUrl}
-                        alt="firmalogo"
-                    />
+                    <Avatar size="xl" src={bedpres.logoUrl} alt="firmalogo" />
                     <Center ml="2em">
                         <NextLink href={`/bedpres/${bedpres.slug}`} passHref>
                             <LinkOverlay>
-                                <Heading fontWeight="regular" size="lg">
+                                <Heading display={['none', 'block']} fontWeight="regular" size="lg">
                                     {bedpres.title}
                                 </Heading>
                             </LinkOverlay>

--- a/src/components/bedpres-block.tsx
+++ b/src/components/bedpres-block.tsx
@@ -8,7 +8,6 @@ import {
     Flex,
     Stack,
     StackDivider,
-    Img,
     Heading,
     Spacer,
     useColorModeValue,

--- a/src/components/static-info.tsx
+++ b/src/components/static-info.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+import { Tabs, Grid, GridItem, TabList, Tab, TabPanels, TabPanel } from '@chakra-ui/react';
+import Markdown from 'markdown-to-jsx';
+import MapMarkdownChakra from '../markdown';
+import ContentBox from './content-box';
+
+const StaticInfo = ({
+    tabNames,
+    markdownFiles,
+}: {
+    tabNames: Array<string>;
+    markdownFiles: Array<string>;
+}): JSX.Element => {
+    return (
+        <Tabs orientation="vertical">
+            <Grid w="100%" templateColumns={['repeat(1, 1fr)', null, null, 'repeat(4, 1fr)']} gap="4">
+                <GridItem minW="0" colSpan={1}>
+                    <ContentBox>
+                        <TabList>
+                            {tabNames.map((tabName: string) => (
+                                <Tab>{tabName}</Tab>
+                            ))}
+                        </TabList>
+                    </ContentBox>
+                </GridItem>
+                <GridItem colStart={[1, null, null, 2]} colSpan={[1, null, null, 3]} rowSpan={2}>
+                    <ContentBox>
+                        <TabPanels>
+                            {markdownFiles.map((mdFile: string) => (
+                                <TabPanel>
+                                    <Markdown options={MapMarkdownChakra}>{mdFile}</Markdown>
+                                </TabPanel>
+                            ))}
+                        </TabPanels>
+                    </ContentBox>
+                </GridItem>
+            </Grid>
+        </Tabs>
+    );
+};
+
+export default StaticInfo;

--- a/src/components/static-info.tsx
+++ b/src/components/static-info.tsx
@@ -13,13 +13,15 @@ const StaticInfo = ({
     markdownFiles: Array<string>;
 }): JSX.Element => {
     return (
-        <Tabs orientation="vertical">
+        <Tabs isLazy orientation="vertical">
             <Grid w="100%" templateColumns={['repeat(1, 1fr)', null, null, 'repeat(4, 1fr)']} gap="4">
                 <GridItem minW="0" maxW="100%" colSpan={1}>
                     <ContentBox>
                         <TabList>
                             {tabNames.map((tabName: string) => (
-                                <Tab>{tabName}</Tab>
+                                <Tab whiteSpace="normal" wordBreak="break-word" fontSize="xl">
+                                    {tabName}
+                                </Tab>
                             ))}
                         </TabList>
                     </ContentBox>

--- a/src/components/static-info.tsx
+++ b/src/components/static-info.tsx
@@ -15,7 +15,7 @@ const StaticInfo = ({
     return (
         <Tabs orientation="vertical">
             <Grid w="100%" templateColumns={['repeat(1, 1fr)', null, null, 'repeat(4, 1fr)']} gap="4">
-                <GridItem minW="0" colSpan={1}>
+                <GridItem minW="0" maxW="100%" colSpan={1}>
                     <ContentBox>
                         <TabList>
                             {tabNames.map((tabName: string) => (
@@ -24,7 +24,7 @@ const StaticInfo = ({
                         </TabList>
                     </ContentBox>
                 </GridItem>
-                <GridItem colStart={[1, null, null, 2]} colSpan={[1, null, null, 3]} rowSpan={2}>
+                <GridItem minW="0" maxW="100%" colStart={[1, null, null, 2]} colSpan={[1, null, null, 3]} rowSpan={2}>
                     <ContentBox>
                         <TabPanels>
                             {markdownFiles.map((mdFile: string) => (

--- a/src/pages/for-bedrifter.tsx
+++ b/src/pages/for-bedrifter.tsx
@@ -1,42 +1,20 @@
 import React from 'react';
 
-import { Box, Tabs, TabList, TabPanels, Tab, TabPanel } from '@chakra-ui/react';
-import Markdown from 'markdown-to-jsx';
 import Layout from '../components/layout';
 import SEO from '../components/seo';
-import MapMarkdownChakra from '../markdown';
 import forBedrifter from '../../public/static/for-bedrifter/for-bedrifter.md';
 import bedriftspresentasjon from '../../public/static/for-bedrifter/bedriftspresentasjon.md';
 import stillingsutlysninger from '../../public/static/for-bedrifter/stillingsutlysninger.md';
+import StaticInfo from '../components/static-info';
 
 const ForBedrifterPage = (): JSX.Element => {
     return (
         <Layout>
             <SEO title="Om Oss" />
-            <Tabs defaultIndex={0} align="start" orientation="vertical">
-                <TabList padding="2" width="20%" marginBottom="0">
-                    <Tab>For bedrifter</Tab>
-                    <Tab>Bedriftspresentasjon</Tab>
-                    <Tab>Stillingsutlysninger</Tab>
-                </TabList>
-                <TabPanels>
-                    <TabPanel>
-                        <Box padding="5">
-                            <Markdown options={MapMarkdownChakra}>{forBedrifter}</Markdown>
-                        </Box>
-                    </TabPanel>
-                    <TabPanel>
-                        <Box padding="5">
-                            <Markdown options={MapMarkdownChakra}>{bedriftspresentasjon}</Markdown>
-                        </Box>
-                    </TabPanel>
-                    <TabPanel>
-                        <Box padding="5">
-                            <Markdown options={MapMarkdownChakra}>{stillingsutlysninger}</Markdown>
-                        </Box>
-                    </TabPanel>
-                </TabPanels>
-            </Tabs>
+            <StaticInfo
+                tabNames={['For bedrifter', 'Bedriftspresentasjon', 'Stillingsutlysninger']}
+                markdownFiles={[forBedrifter, bedriftspresentasjon, stillingsutlysninger]}
+            />
         </Layout>
     );
 };

--- a/src/pages/for-studenter.tsx
+++ b/src/pages/for-studenter.tsx
@@ -1,42 +1,20 @@
 import React from 'react';
 
-import { Box, Tabs, TabList, TabPanels, Tab, TabPanel } from '@chakra-ui/react';
-import Markdown from 'markdown-to-jsx';
 import Layout from '../components/layout';
 import SEO from '../components/seo';
-import MapMarkdownChakra from '../markdown';
 import undergrupper from '../../public/static/for-studenter/undergrupper.md';
 import underorganisasjoner from '../../public/static/for-studenter/underorganisasjoner.md';
 import masterinfo from '../../public/static/for-studenter/masterinfo.md';
+import StaticInfo from '../components/static-info';
 
 const ForStudenterPage = (): JSX.Element => {
     return (
         <Layout>
             <SEO title="Om Oss" />
-            <Tabs defaultIndex={0} align="start" orientation="vertical">
-                <TabList padding="2" width="20%" marginBottom="0">
-                    <Tab>Undergrupper</Tab>
-                    <Tab>Underorganisasjoner</Tab>
-                    <Tab>Masterinfo</Tab>
-                </TabList>
-                <TabPanels>
-                    <TabPanel>
-                        <Box padding="5">
-                            <Markdown options={MapMarkdownChakra}>{undergrupper}</Markdown>
-                        </Box>
-                    </TabPanel>
-                    <TabPanel>
-                        <Box padding="5">
-                            <Markdown options={MapMarkdownChakra}>{underorganisasjoner}</Markdown>
-                        </Box>
-                    </TabPanel>
-                    <TabPanel>
-                        <Box padding="5">
-                            <Markdown options={MapMarkdownChakra}>{masterinfo}</Markdown>
-                        </Box>
-                    </TabPanel>
-                </TabPanels>
-            </Tabs>
+            <StaticInfo
+                tabNames={['Undergrupper', 'Underorganisasjoner', 'Masterinfo']}
+                markdownFiles={[undergrupper, underorganisasjoner, masterinfo]}
+            />
         </Layout>
     );
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -29,7 +29,7 @@ const IndexPage = ({
         <Layout>
             <SEO title="Home" />
             <SimpleGrid columns={[1, null, 2]} spacing="5" mb="5">
-                <Stack spacing="5">
+                <Stack minW="0" spacing="5">
                     <ContentBox>
                         <Heading>Hovedsamarbeidspartner</Heading>
                         <Divider mb="1em" />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -28,10 +28,10 @@ const IndexPage = ({
     return (
         <Layout>
             <SEO title="Home" />
-            <SimpleGrid columns={[1, null, 2]} spacing="5" mb="5">
+            <SimpleGrid columns={[null, 1, null, 2]} spacing="5" mb="5">
                 <Stack minW="0" spacing="5">
                     <ContentBox>
-                        <Heading>Hovedsamarbeidspartner</Heading>
+                        <Heading sizes={['xs', 'md']}>Hovedsamarbeidspartner</Heading>
                         <Divider mb="1em" />
                         <Img src={bekkLogo} filter={bekkLogoFilter} htmlWidth="300px" />
                     </ContentBox>

--- a/src/pages/om-oss.tsx
+++ b/src/pages/om-oss.tsx
@@ -1,42 +1,20 @@
 import React from 'react';
 
-import { Box, Tabs, TabList, TabPanels, Tab, TabPanel } from '@chakra-ui/react';
-import Markdown from 'markdown-to-jsx';
 import Layout from '../components/layout';
 import SEO from '../components/seo';
-import MapMarkdownChakra from '../markdown';
 import hvemErVi from '../../public/static/om-oss/hvem-er-vi.md';
 import instituttraadet from '../../public/static/om-oss/instituttraadet.md';
 import statutter from '../../public/static/om-oss/statutter.md';
+import StaticInfo from '../components/static-info';
 
 const OmOssPage = (): JSX.Element => {
     return (
         <Layout>
-            <SEO title="Om Oss" />
-            <Tabs defaultIndex={0} align="start" orientation="vertical">
-                <TabList padding="2" width="20%" marginBottom="0">
-                    <Tab>Hvem er vi?</Tab>
-                    <Tab>Instituttrådet</Tab>
-                    <Tab>Statutter</Tab>
-                </TabList>
-                <TabPanels>
-                    <TabPanel>
-                        <Box padding="5">
-                            <Markdown options={MapMarkdownChakra}>{hvemErVi}</Markdown>
-                        </Box>
-                    </TabPanel>
-                    <TabPanel>
-                        <Box padding="5">
-                            <Markdown options={MapMarkdownChakra}>{instituttraadet}</Markdown>
-                        </Box>
-                    </TabPanel>
-                    <TabPanel>
-                        <Box padding="5">
-                            <Markdown options={MapMarkdownChakra}>{statutter}</Markdown>
-                        </Box>
-                    </TabPanel>
-                </TabPanels>
-            </Tabs>
+            <SEO title="Om echo" />
+            <StaticInfo
+                tabNames={['Hvem er vi?', 'Instituttrådet', 'Statutter']}
+                markdownFiles={[hvemErVi, instituttraadet, statutter]}
+            />
         </Layout>
     );
 };


### PR DESCRIPTION
Stylized the static info pages. Created a component `StaticInfo` which is used by all static info pages.
This component takes a list of descriptions and a list of markdown files and maps these with the chakra-ui's `Tabs`-component.
Also fixed some responsiveness in index.

- :lipstick: Stylized static info
- :lipstick: Responsive bedpres-block and no min-width for index stack
- :rotating_light: Removed unused import
- :lipstick: Set min-width and max-width for static-info
- :lipstick: Better responsiveness for index
- :art: Fixed tabs responsiveness and size
