### PR TITLE
Bedpres sorting by upcoming

### DIFF
--- a/src/lib/api/schema.ts
+++ b/src/lib/api/schema.ts
@@ -114,7 +114,7 @@ const GET_BEDPRES_PATHS = `
 
 const GET_N_BEDPRESES = `
     query ($n: Int!) {
-        bedpresCollection(limit: $n) {
+        bedpresCollection(limit: $n, order: date_ASC) {
             items {
                 title
                 slug


### PR DESCRIPTION
Changed the query to fetch bedpreses, such that they are sorted by upcoming.
