### PR TITLE
Fixed bug in bedpres-block

### DIFF
--- a/src/lib/api/bedpres.ts
+++ b/src/lib/api/bedpres.ts
@@ -22,6 +22,7 @@ const BedpresAPI = {
                 query: GET_N_BEDPRESES,
                 variables: {
                     n,
+                    date: moment().subtract(12, 'hours').utcOffset(0).format('YYYY-MM-DDTHH:mm:ss.SSSZ'),
                 },
             });
 

--- a/src/lib/api/bedpres.ts
+++ b/src/lib/api/bedpres.ts
@@ -22,7 +22,7 @@ const BedpresAPI = {
                 query: GET_N_BEDPRESES,
                 variables: {
                     n,
-                    date: moment().subtract(12, 'hours').utcOffset(0).format('YYYY-MM-DDTHH:mm:ss.SSSZ'),
+                    date: moment().utcOffset(0).format('YYYY-MM-DDTHH:mm:ss.SSSZ'),
                 },
             });
 

--- a/src/lib/api/schema.ts
+++ b/src/lib/api/schema.ts
@@ -113,8 +113,8 @@ const GET_BEDPRES_PATHS = `
 `;
 
 const GET_N_BEDPRESES = `
-    query ($n: Int!) {
-        bedpresCollection(limit: $n, order: date_ASC) {
+    query ($n: Int!, $date: DateTime) {
+        bedpresCollection(limit: $n, order: date_ASC, where: { date_gt: $date}) {
             items {
                 title
                 slug


### PR DESCRIPTION
Fixed a bug where previous bedpreses would show up in upcoming bedpreses block.
Please see the changed query.
