### PR TITLE
Timeout integer overflow fix

### DIFF
--- a/src/pages/bedpres/[slug].tsx
+++ b/src/pages/bedpres/[slug].tsx
@@ -37,13 +37,13 @@ const BedpresPage = ({ bedpres, error }: { bedpres: Bedpres; error: string }): J
     const formattedRegDate = bedpres ? moment(bedpres.registrationTime).format('DD. MMM YYYY, HH:mm') : null;
     const time =
         !bedpres || moment(bedpres.registrationTime).valueOf() - moment().valueOf() < 0
-            ? 1000000
+            ? 0
             : moment(bedpres.registrationTime).valueOf() - moment().valueOf();
 
     useEffect(() => {
         setTimeout(() => {
             router.replace(router.asPath);
-        }, time);
+        }, Math.min(time, 86400000)); // absurdly large numbers here will literally destroy page, hence 1 day in ms.
     }, [time, router]);
 
     return (


### PR DESCRIPTION
Fixed a bug where too big integers would be passed to `setTimeout` in `bedpres/[slug].tsx`. This caused the page to constantly fetch data.

The bug would occur when time in ms to bedpres registration starts is bigger than 2^32.