### PR TITLE
🔧 Made Renovate Bot not create PR before stable

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,7 @@
 {
-  "extends": [
-    "config:base"
-  ],
-  "labels": ["dependencies :handshake:"],
-  "prHourlyLimit": 0,
-  "stabilityDays": 3
+    "extends": ["config:base"],
+    "labels": ["dependencies :handshake:"],
+    "prHourlyLimit": 0,
+    "stabilityDays": 3,
+    "prCreation": "not-pending"
 }


### PR DESCRIPTION
Renovate Bot will not create new PR before dependency is stable for amount of days given in "stabilityDays".